### PR TITLE
regex string changes

### DIFF
--- a/logs_analyzer/chapter1/scala/src/main/scala/com/databricks/apps/logs/ApacheAccessLog.scala
+++ b/logs_analyzer/chapter1/scala/src/main/scala/com/databricks/apps/logs/ApacheAccessLog.scala
@@ -8,7 +8,7 @@ case class ApacheAccessLog(ipAddress: String, clientIdentd: String,
 }
 
 object ApacheAccessLog {
-  val PATTERN = """^(\S+) (\S+) (\S+) \[([\w:/]+\s[+\-]\d{4})\] "(\S+) (\S+) (\S+)" (\d{3}) (\d+)""".r
+  val PATTERN = """^(\S+) (\S+) (\S+) \[([^]+)([^\]]+)\] "(\S+) (\S+) (\S+)" (\d{3}) (\d+)""".r
 
   def parseLogLine(log: String): ApacheAccessLog = {
     val res = PATTERN.findFirstMatchIn(log)


### PR DESCRIPTION
Following regex is not parsing the apache log.

so I've made the changes in new branch named FK7-patch-1.

`^(\S+) (\S+) (\S+) \[([\w:/]+\s[+\-]\d{4})\] "(\S+) (\S+) (\S+)" (\d{3}) (\d+)`

`1.1.1.1 - - [21/Jul/2014:10:00:00 -0800] "GET /chapter1/java/src/main/java/com/databricks/apps/logs/LogAnalyzer.java HTTP/1.1" 200 1234`
